### PR TITLE
Allow to manipulate request body, headers and method before a request is proxied

### DIFF
--- a/revproxy-ns-http-procs.tcl
+++ b/revproxy-ns-http-procs.tcl
@@ -13,6 +13,10 @@ namespace eval ::revproxy::ns_http {
         {-validation_callback ""}
         {-exception_callback "::revproxy::exception"}
         {-backend_reply_callback ""}
+        -method
+        -content
+        -contentfile
+        -queryHeaders
     } {
         #
         # Now perform the transmission... but before this, call the
@@ -24,11 +28,10 @@ namespace eval ::revproxy::ns_http {
             {*}$validation_callback -url $url
         }
 
-        set queryHeaders [ns_conn headers]
         set binary false
         set extraArgs {}
 
-        switch [ns_conn method] {
+        switch $method {
             PUT -
             POST {
                 set contentType [ns_set iget $queryHeaders content-type]
@@ -36,13 +39,10 @@ namespace eval ::revproxy::ns_http {
                     && [ns_encodingfortype $contentType] eq "binary"} {
                     set binary true
                 }
-                set contentfile [ns_conn contentfile]
                 if {$contentfile ne ""} {
                     lappend extraArgs -body_file $contentfile
-                } elseif {$binary} {
-                    lappend extraArgs -body [ns_conn content -binary]
                 } else {
-                    lappend extraArgs -body [ns_conn content]
+                    lappend extraArgs -body $content
                 }
             }
             default {}

--- a/revproxy-procs.tcl
+++ b/revproxy-procs.tcl
@@ -53,7 +53,7 @@ namespace eval ::revproxy {
         {-backendconnection ""}
         {-content ""}
         {-contentfile ""}
-        {-headers ""}
+        {-queryHeaders ""}
     } {
 
         if {$backendconnection eq ""} {

--- a/revproxy-procs.tcl
+++ b/revproxy-procs.tcl
@@ -35,8 +35,8 @@ namespace eval ::revproxy {
     #
     # By default, headers method and request body will be those of the
     # current request. One can craft a custom request to be forwarded
-    # to the backend overriding these parameters via the "method",
-    # "content" / "contentfile" and "queryHeaders" flags.
+    # to the backend overriding these parameters via the "content" /
+    # "contentfile" and "queryHeaders" flags.
     #
 
     nsf::proc upstream {
@@ -51,7 +51,6 @@ namespace eval ::revproxy {
         {-url_rewrite_callback "::revproxy::rewrite_url"}
         {-backend_reply_callback ""}
         {-backendconnection ""}
-        {-method ""}
         {-content ""}
         {-contentfile ""}
         {-headers ""}
@@ -155,10 +154,6 @@ namespace eval ::revproxy {
             ns_set iupdate $queryHeaders x-ssl-request 1
         }
 
-        if {$method eq ""} {
-            set method [ns_conn method]
-        }
-
         set contentType [ns_set iget $queryHeaders content-type]
         set binary [expr {$contentType ne "" && [ns_encodingfortype $contentType] eq "binary"}]
 
@@ -188,7 +183,7 @@ namespace eval ::revproxy {
                     -validation_callback $validation_callback \
                     -exception_callback $exception_callback \
                     -backend_reply_callback $backend_reply_callback \
-                    -method $method \
+                    -method $when \
                     -content $content \
                     -contentfile $contentfile \
                     -queryHeaders $queryHeaders \

--- a/revproxy-procs.tcl
+++ b/revproxy-procs.tcl
@@ -32,6 +32,12 @@ namespace eval ::revproxy {
     #
     # Serve the requested file from an upstream server, which might be
     # an HTTP or HTTPS server.
+    #
+    # By default, headers method and request body will be those of the
+    # current request. One can craft a custom request to be forwarded
+    # to the backend overriding these parameters via the "method",
+    # "content" / "contentfile" and "queryHeaders" flags.
+    #
 
     nsf::proc upstream {
         when
@@ -45,6 +51,10 @@ namespace eval ::revproxy {
         {-url_rewrite_callback "::revproxy::rewrite_url"}
         {-backend_reply_callback ""}
         {-backendconnection ""}
+        {-method ""}
+        {-content ""}
+        {-contentfile ""}
+        {-headers ""}
     } {
 
         if {$backendconnection eq ""} {
@@ -130,7 +140,9 @@ namespace eval ::revproxy {
         # Get header fields from request, add x-forwarded-for,
         # x-forwarded-proto, and x-ssl-request (if appropriate).
         #
-        set queryHeaders [ns_conn headers]
+        if {$queryHeaders eq ""} {
+            set queryHeaders [ns_conn headers]
+        }
 
         set XForwardedFor [split [ns_set iget $queryHeaders "x-forwarded-for" ""] " ,"]
         set XForwardedFor [lmap e $XForwardedFor {if {$e eq ""} continue}]
@@ -141,6 +153,27 @@ namespace eval ::revproxy {
         ns_set iupdate $queryHeaders x-forwarded-proto $proto
         if {$proto eq "https"} {
             ns_set iupdate $queryHeaders x-ssl-request 1
+        }
+
+        if {$method eq ""} {
+            set method [ns_conn method]
+        }
+
+        set contentType [ns_set iget $queryHeaders content-type]
+        set binary [expr {$contentType ne "" && [ns_encodingfortype $contentType] eq "binary"}]
+
+        if {$content ne ""} {
+            ns_set iupdate $queryHeaders content-length [string length $content]
+        } elseif {$binary} {
+            set content [ns_conn content -binary]
+        } else {
+            set content [ns_conn content]
+        }
+
+        if {$contentfile ne ""} {
+            ns_set iupdate $queryHeaders content-length [file size $contentfile]
+        } else {
+            set contentfile [ns_conn contentfile]
         }
 
         #
@@ -155,6 +188,10 @@ namespace eval ::revproxy {
                     -validation_callback $validation_callback \
                     -exception_callback $exception_callback \
                     -backend_reply_callback $backend_reply_callback \
+                    -method $method \
+                    -content $content \
+                    -contentfile $contentfile \
+                    -queryHeaders $queryHeaders \
                    ]
     }
 


### PR DESCRIPTION
In this PR I implement some extra flag for the upstream api that allow to send a request to a backend where the request body and headers are not those from the current connection, but completely arbitrary.

This allows to create wrappers to web apis that can return a streaming response, such as https://github.com/ollama/ollama/blob/main/docs/api.md

In my wrapper I can then differentiate between:
* "normal" calls -> build a request, send it to the endpoint via e.g. ns_http, return the reply
* streaming calls -> build the request, send it to the backend, let the backend serve the reply through us as proxy

The previous behavior should be unchanged by this new feature.

Many thanks for any feedback on this.